### PR TITLE
Improve buffer-centric workflow and UI experience

### DIFF
--- a/key_mappings.md
+++ b/key_mappings.md
@@ -35,12 +35,20 @@
 
 | Key Combination | Package/Source | Description |
 |----------------|----------------|-------------|
-| `Space e` | nvim-tree | Toggle file explorer |
+| `Space .` | nvim-tree | Toggle file explorer |
 | `Space f f` | telescope.nvim | Find files in current working directory |
 | `Space f s` | telescope.nvim | Live grep search in files |
 | `Space f c` | telescope.nvim | Find string under cursor in current directory |
 | `Space f b` | telescope.nvim | List open buffers |
 | `Space f h` | telescope.nvim | List available help tags |
+
+## Buffer Management
+
+| Key Combination | Package/Source | Description |
+|----------------|----------------|-------------|
+| `Space b j` | Core Neovim | Go to next buffer (matches telescope down) |
+| `Space b k` | Core Neovim | Go to previous buffer (matches telescope up) |
+| `Space b d` | Core Neovim | Delete current buffer |
 
 ## Telescope Navigation (Insert Mode)
 
@@ -49,6 +57,7 @@
 | `⌃ + k` | telescope.nvim | Move to previous result in telescope |
 | `⌃ + j` | telescope.nvim | Move to next result in telescope |
 | `⌃ + q` | telescope.nvim | Send selected items to quickfix list |
+| `⌃ + d` | telescope.nvim | Delete buffer (only in buffer picker) |
 
 ## Autocompletion (Insert Mode)
 

--- a/key_mappings.md
+++ b/key_mappings.md
@@ -46,8 +46,8 @@
 
 | Key Combination | Package/Source | Description |
 |----------------|----------------|-------------|
-| `Space b j` | Core Neovim | Go to next buffer (matches telescope down) |
-| `Space b k` | Core Neovim | Go to previous buffer (matches telescope up) |
+| `Space j` | Core Neovim | Go to next buffer (matches telescope down) |
+| `Space k` | Core Neovim | Go to previous buffer (matches telescope up) |
 | `Space b d` | Core Neovim | Delete current buffer |
 
 ## Telescope Navigation (Insert Mode)

--- a/lua/bruce/core/keymaps.lua
+++ b/lua/bruce/core/keymaps.lua
@@ -28,7 +28,7 @@ keymap.set("n", "<leader>th", ":tabp<CR>") --  go to previous tab
 keymap.set("n", "<leader>sm", ":MaximizerToggle<CR>") -- toggle split window maximization
 
 -- nvim-tree
-keymap.set("n", "<leader>e", ":NvimTreeToggle<CR>")
+keymap.set("n", "<leader>.", ":NvimTreeToggle<CR>")
 
 -- telescope
 keymap.set("n", "<leader>ff", "<cmd>Telescope find_files<cr>") -- find files within current working directory, respects .gitignore
@@ -36,4 +36,9 @@ keymap.set("n", "<leader>fs", "<cmd>Telescope live_grep<cr>") -- find string in 
 keymap.set("n", "<leader>fc", "<cmd>Telescope grep_string<cr>") -- find string under cursor in current working directory
 keymap.set("n", "<leader>fb", "<cmd>Telescope buffers<cr>") -- list open buffers in current neovim instance
 keymap.set("n", "<leader>fh", "<cmd>Telescope help_tags<cr>") -- list available help tags
+
+-- buffer navigation (matches telescope j/k pattern)
+keymap.set("n", "<leader>bj", ":bnext<CR>") -- next buffer (j = down/next)
+keymap.set("n", "<leader>bk", ":bprevious<CR>") -- previous buffer (k = up/previous)
+keymap.set("n", "<leader>bd", ":bdelete<CR>") -- delete buffer
 

--- a/lua/bruce/core/keymaps.lua
+++ b/lua/bruce/core/keymaps.lua
@@ -38,7 +38,7 @@ keymap.set("n", "<leader>fb", "<cmd>Telescope buffers<cr>") -- list open buffers
 keymap.set("n", "<leader>fh", "<cmd>Telescope help_tags<cr>") -- list available help tags
 
 -- buffer navigation (matches telescope j/k pattern)
-keymap.set("n", "<leader>bj", ":bnext<CR>") -- next buffer (j = down/next)
-keymap.set("n", "<leader>bk", ":bprevious<CR>") -- previous buffer (k = up/previous)
+keymap.set("n", "<leader>j", ":bnext<CR>") -- next buffer (j = down/next)
+keymap.set("n", "<leader>k", ":bprevious<CR>") -- previous buffer (k = up/previous)
 keymap.set("n", "<leader>bd", ":bdelete<CR>") -- delete buffer
 

--- a/lua/bruce/plugins/nvim-tree.lua
+++ b/lua/bruce/plugins/nvim-tree.lua
@@ -81,4 +81,25 @@ nvimtree.setup({
 --   require("nvim-tree.api").tree.open()
 -- end
 --
--- vim.api.nvim_create_autocmd({ "VimEnter" }, { callback = open_nvim_tree })
+-- open nvim-tree on startup when no file is specified
+local function open_nvim_tree(data)
+  -- buffer is a [No Name] (no specific file passed)
+  local no_name = data.file == "" and vim.bo[data.buf].buftype == ""
+
+  -- buffer is a directory
+  local directory = vim.fn.isdirectory(data.file) == 1
+
+  if not no_name and not directory then
+    return
+  end
+
+  -- change to the directory
+  if directory then
+    vim.cmd.cd(data.file)
+  end
+
+  -- open the tree
+  require("nvim-tree.api").tree.open()
+end
+
+vim.api.nvim_create_autocmd({ "VimEnter" }, { callback = open_nvim_tree })

--- a/lua/bruce/plugins/telescope.lua
+++ b/lua/bruce/plugins/telescope.lua
@@ -22,6 +22,18 @@ telescope.setup({
       },
     },
   },
+  pickers = {
+    buffers = {
+      mappings = {
+        i = {
+          ["<C-d>"] = actions.delete_buffer, -- delete buffer in telescope
+        },
+        n = {
+          ["<C-d>"] = actions.delete_buffer, -- delete buffer in normal mode too
+        },
+      },
+    },
+  },
 })
 
 telescope.load_extension("fzf")


### PR DESCRIPTION
## Summary
• Enhances buffer management with intuitive navigation keybindings
• Improves file tree accessibility and auto-opening behavior
• Fixes telescope buffer deletion functionality

## Key Changes
- **File tree toggle**: Changed from `<leader>e` to `<leader>.` (more intuitive "here" concept)
- **Buffer navigation**: Added `<leader>bj/bk/bd` matching telescope's j/k movement pattern
- **Auto-open tree**: nvim-tree opens automatically when no specific file is provided
- **Telescope fix**: `Ctrl+d` now properly deletes buffers in buffer picker
- **Documentation**: Updated key mappings with new buffer management section

## Benefits
- More consistent navigation patterns across tools
- Better buffer-centric workflow (more Vim-native)
- Improved discoverability with auto-opening file tree
- Enhanced productivity with fixed telescope functionality

## Test plan
- [x] Verify `<leader>.` toggles file tree
- [ ] Test buffer navigation with `<leader>bj/bk/bd`
- [x] Confirm auto-opening when running `nvim` without arguments
- [x] Test `Ctrl+d` deletes buffers in telescope buffer picker
- [ ] Verify documentation accuracy

🤖 Generated with [Claude Code](https://claude.ai/code)